### PR TITLE
harden: fix security issue in prepare-overview-review.py

### DIFF
--- a/scripts/prepare-overview-review.py
+++ b/scripts/prepare-overview-review.py
@@ -25,8 +25,8 @@ import json
 import math
 from pathlib import Path
 import posixpath
-from xml.dom import minidom
-from xml.parsers.expat import ExpatError
+from defusedxml import minidom
+from pyexpat import ExpatError
 from zipfile import BadZipFile, ZipFile
 
 


### PR DESCRIPTION
## Summary
Harden input handling in `scripts/prepare-overview-review.py` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | gitlab.bandit.B313.B314.B315.B316.B318.B319.B320.B405.B406.B407.B408.B409.B410 |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `gitlab.bandit.B313.B314.B315.B316.B318.B319.B320.B405.B406.B407.B408.B409.B410` |
| **File** | `scripts/prepare-overview-review.py:28` |
| **Assessment** | Defensive hardening |

**Description**: Found use of the native Python XML libraries, which is vulnerable to XML external entity (XXE)
attacks. The Python documentation recommends the 'defusedxml' library instead. Use 'defusedxml'.
See https://github.com/tiran/defusedxml for more information.


## Changes
- `scripts/prepare-overview-review.py`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=gitlab.bandit.B313.B314.B315.B316.B318.B319.B320.B405.B406.B407.B408.B409.B410 scanner=semgrep -->
